### PR TITLE
Added additional logging to figure out empty folder bug and made slight readability improvements

### DIFF
--- a/LS_Pycro_App/acquisition/imaging.py
+++ b/LS_Pycro_App/acquisition/imaging.py
@@ -318,7 +318,7 @@ class ZStack(ImagingSequence):
         #calls default camera reset function from super class
         super()._camera_timeout_response()
         interval_ms = self._region.z_stack_step_size/self._adv_settings.z_stack_stage_speed*constants.S_TO_MS
-        Plc.set_to_external_trigger_mode(interval_ms)
+        Plc.set_to_external_trigger_pulse_mode(interval_ms)
 
     def _set_summary_metadata(self, channel):
         summary_builder = pycro.SummaryMetadataBuilder().z(self._region.z_stack_num_frames).step(
@@ -383,7 +383,7 @@ class ZStack(ImagingSequence):
         if not self._acq_settings.is_step_size_same():
             if not Galvo or (Galvo.settings.is_lsrm and (self._region.snap_enabled or self._region.video_enabled)):
                 interval_ms = self._region.z_stack_step_size/self._adv_settings.z_stack_stage_speed*constants.S_TO_MS
-                Plc.set_to_external_trigger_mode(interval_ms)
+                Plc.set_to_external_trigger_pulse_mode(interval_ms)
         Stage.set_z_position(self._region.z_stack_start_pos)
         Stage.initialize_scan(self._region.z_stack_start_pos, self._region.z_stack_end_pos)
 
@@ -511,7 +511,7 @@ class DeconZStack(ZStack):
     def _initialize_z_stack(self):
         if not self._acq_settings.is_step_size_same():
             interval_ms = self._region.z_stack_step_size/self._adv_settings.z_stack_stage_speed*constants.S_TO_MS
-            Plc.set_to_external_trigger_mode(interval_ms)
+            Plc.set_to_external_trigger_pulse_mode(interval_ms)
         Stage.set_z_position(self._region.z_stack_start_pos)
         Stage.initialize_scan(self._region.z_stack_start_pos, self._region.z_stack_end_pos)
 

--- a/LS_Pycro_App/acquisition/main.py
+++ b/LS_Pycro_App/acquisition/main.py
@@ -156,7 +156,7 @@ class CLSAcquisition(Acquisition, HardwareAcquisition):
 
     def _init_plc(self):
         interval_ms = (self._acq_settings.get_first_step_size()/self._adv_settings.z_stack_stage_speed)*constants.S_TO_MS
-        Plc.set_to_external_trigger_mode(interval_ms)
+        Plc.set_to_external_trigger_pulse_mode(interval_ms)
 
     def _reset_hardware(self):
         #set PLC to pulse continuously to send signal to camera in case it's frozen
@@ -223,7 +223,7 @@ class HTLSAcquisition(Acquisition, HardwareAcquisition):
 
     def _init_plc(self):
         interval_ms = self._htls_settings.fish_settings.region_list[0].z_stack_step_size/self._adv_settings.z_stack_stage_speed*constants.S_TO_MS
-        Plc.set_to_external_trigger_mode(interval_ms)
+        Plc.set_to_external_trigger_pulse_mode(interval_ms)
 
     def _reset_hardware(self):
         Pump.terminate()

--- a/LS_Pycro_App/controllers/galvo_controller.py
+++ b/LS_Pycro_App/controllers/galvo_controller.py
@@ -6,7 +6,7 @@ from PyQt5 import QtGui
 
 from LS_Pycro_App.hardware import Galvo, Camera, Plc, exceptions
 from LS_Pycro_App.views import GalvoDialog
-from LS_Pycro_App.utils import general_functions
+from LS_Pycro_App.utils import constants, general_functions
 
 
 class GalvoController(object):
@@ -203,7 +203,7 @@ class GalvoController(object):
         with contextlib.suppress(exceptions.HardwareException):
             if self.galvo_dialog.scanning_check_box.isChecked():
                 if Galvo.settings.is_lsrm:
-                    Plc.set_continuous_pulses(Galvo.settings.lsrm_framerate)
+                    Plc.set_to_continuous_pulse_mode((1/Galvo.settings.lsrm_framerate)*constants.S_TO_MS)
                     Galvo.set_lsrm_mode()
                 else:
                     Galvo.set_dslm_mode()

--- a/LS_Pycro_App/hardware/multi_device.py
+++ b/LS_Pycro_App/hardware/multi_device.py
@@ -1,0 +1,36 @@
+import logging
+
+from LS_Pycro_App.hardware import Plc, Camera, Galvo
+from LS_Pycro_App.hardware.camera import Hamamatsu
+from LS_Pycro_App.utils import constants, general_functions
+
+logger = logging.getLogger(__name__)
+
+def set_continuous_lsrm(framerate):
+    if Galvo and Camera is Hamamatsu:
+        Galvo.settings.lsrm_framerate = min(framerate, Camera.LSRM_MAX_FRAMERATE)
+        Galvo.set_lsrm_mode()
+        Plc.set_to_continuous_pulse_mode(1/framerate)
+        Camera.set_lsrm_mode(Galvo.settings.lsrm_ili, Galvo.settings.lsrm_num_lines)
+    else:
+        message = "Cannot set system to continuous lsrm."
+        if not Galvo:
+            logger.warning(f"{message} Galvo is None.")
+        if not (Camera is Hamamatsu):
+            logger.warning(f"{message} Galvo is not Hamamatsu.")
+
+def set_triggered_lsrm(exposure, pulse_interval_ms):
+    if Galvo and Plc and (Camera is Hamamatsu):
+        framerate = general_functions.exposure_to_frequency(exposure)
+        Galvo.settings.lsrm_framerate = min(framerate, Camera.LSRM_MAX_FRAMERATE)
+        if pulse_interval_ms*constants.MS_TO_S > 1/Camera.LSRM_MAX_FRAMERATE:
+            raise ValueError("pulse interval is too short for LSRM")
+        Galvo.set_lsrm_mode()
+        Plc.set_to_external_trigger_mode(pulse_interval_ms)
+        Camera.set_lsrm_mode(Galvo.settings.lsrm_ili, Galvo.settings.lsrm_num_lines)
+    else:
+        message = "Cannot set system to continuous lsrm."
+        if not Galvo:
+            logger.warning(f"{message} Galvo is None.")
+        if not (Camera is Hamamatsu):
+            logger.warning(f"{message} Galvo is not Hamamatsu.")

--- a/LS_Pycro_App/hardware/multi_device.py
+++ b/LS_Pycro_App/hardware/multi_device.py
@@ -26,7 +26,7 @@ def set_triggered_lsrm(exposure, pulse_interval_ms):
         if pulse_interval_ms*constants.MS_TO_S > 1/Camera.LSRM_MAX_FRAMERATE:
             raise ValueError("pulse interval is too short for LSRM")
         Galvo.set_lsrm_mode()
-        Plc.set_to_external_trigger_mode(pulse_interval_ms)
+        Plc.set_to_external_trigger_pulse_mode(pulse_interval_ms)
         Camera.set_lsrm_mode(Galvo.settings.lsrm_ili, Galvo.settings.lsrm_num_lines)
     else:
         message = "Cannot set system to continuous lsrm."

--- a/LS_Pycro_App/hardware/multi_device.py
+++ b/LS_Pycro_App/hardware/multi_device.py
@@ -33,4 +33,4 @@ def set_triggered_lsrm(exposure, pulse_interval_ms):
         if not Galvo:
             logger.warning(f"{message} Galvo is None.")
         if not (Camera is Hamamatsu):
-            logger.warning(f"{message} Galvo is not Hamamatsu.")
+            logger.warning(f"{message} Camera is not Hamamatsu.")

--- a/LS_Pycro_App/utils/constants.py
+++ b/LS_Pycro_App/utils/constants.py
@@ -21,4 +21,7 @@ MIN_TO_S = 60
 S_TO_MIN = 1/60
 S_IN_MIN = 60
 TO_TENTHS = 10
+
+# pulse interval used in camera freeze recovery.
+CAMERA_RECOVERY_PULSE_INTERVAL_MS = 20
     


### PR DESCRIPTION
This PR is meant to address some recent cases where the image folder is empty! I'm going to copy my thoughts from my email to Raghu here:

>The 'Saving zstack' line is kind of a red herring. That's just logged when all of the images have been acquired but haven't all been written to the disk yet. 

>A long time ago, I added an attempt limit to the imaging sequences like videos and z-stacks so that if a transient issue caused less images than expected to be captured, it would reattempt. It used to log when it reattempted, but for some reason I removed this logging, probably during some refactor I did. I'm pretty sure the reason there's an empty folder is because no images are being acquired!

>I think, unfortunately, this is another Tiger Console/stage related issue. The PLC is actually fairly robust in my experience, but the trigger coming from the z stage during a scan has some weird interactions with other modules in the tiger console software that I never really understood.

>I'm going to submit a pull request on github with some additional logging to see if I'm correct (and also some slight readability changes because some of the code was bothering me)."

This, unfortunately, does not directly address the issue, but should help diagnose if this is what I suspect is a hardware issue.